### PR TITLE
イベントアーカイブ取得に成仏ステータスフィルターを追加

### DIFF
--- a/internal/api/api.gen.go
+++ b/internal/api/api.gen.go
@@ -32,6 +32,13 @@ const (
 	VibeVibeTypeWAKARU VibeVibeType = "WAKARU"
 )
 
+// Defines values for GetEventGrumblesParamsPurifiedStatus.
+const (
+	GetEventGrumblesParamsPurifiedStatusAll           GetEventGrumblesParamsPurifiedStatus = "all"
+	GetEventGrumblesParamsPurifiedStatusIsNotPurified GetEventGrumblesParamsPurifiedStatus = "is_not_purified"
+	GetEventGrumblesParamsPurifiedStatusIsPurified    GetEventGrumblesParamsPurifiedStatus = "is_purified"
+)
+
 // Defines values for AddVibeJSONBodyVibeType.
 const (
 	AddVibeJSONBodyVibeTypeWAKARU AddVibeJSONBodyVibeType = "WAKARU"
@@ -181,7 +188,13 @@ type GetEventGrumblesParams struct {
 
 	// Offset オフセット
 	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// PurifiedStatus 成仏ステータスフィルター (is_purified=成仏済み, is_not_purified=成仏していない, all=全て)
+	PurifiedStatus *GetEventGrumblesParamsPurifiedStatus `form:"purified_status,omitempty" json:"purified_status,omitempty"`
 }
+
+// GetEventGrumblesParamsPurifiedStatus defines parameters for GetEventGrumbles.
+type GetEventGrumblesParamsPurifiedStatus string
 
 // GetGrumblesParams defines parameters for GetGrumbles.
 type GetGrumblesParams struct {
@@ -311,6 +324,14 @@ func (siw *ServerInterfaceWrapper) GetEventGrumbles(c *gin.Context) {
 	err = runtime.BindQueryParameter("form", true, false, "offset", c.Request.URL.Query(), &params.Offset)
 	if err != nil {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter offset: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "purified_status" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "purified_status", c.Request.URL.Query(), &params.PurifiedStatus)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter purified_status: %w", err), http.StatusBadRequest)
 		return
 	}
 

--- a/internal/api/strict_handler.go
+++ b/internal/api/strict_handler.go
@@ -68,11 +68,18 @@ func (s *StrictControllerServer) GetEventGrumbles(ctx context.Context, request G
 		offset = *params.Offset
 	}
 
+	var purifiedStatus *string
+	if params.PurifiedStatus != nil {
+		status := string(*params.PurifiedStatus)
+		purifiedStatus = &status
+	}
+
 	query := controller.EventGrumblesQuery{
-		ToxicLevelMin: params.ToxicLevelMin,
-		ToxicLevelMax: params.ToxicLevelMax,
-		Limit:         limit,
-		Offset:        offset,
+		ToxicLevelMin:  params.ToxicLevelMin,
+		ToxicLevelMax:  params.ToxicLevelMax,
+		PurifiedStatus: purifiedStatus,
+		Limit:          limit,
+		Offset:         offset,
 	}
 
 	response, err := s.eventGrumblesController.GetEventGrumbles(ctx, query)

--- a/internal/controller/event_grumbles_controller.go
+++ b/internal/controller/event_grumbles_controller.go
@@ -30,10 +30,11 @@ func NewEventGrumblesController(
 
 // EventGrumblesQuery represents query parameters
 type EventGrumblesQuery struct {
-	ToxicLevelMin *int
-	ToxicLevelMax *int
-	Limit         int
-	Offset        int
+	ToxicLevelMin  *int
+	ToxicLevelMax  *int
+	PurifiedStatus *string // "is_purified", "is_not_purified", "all"
+	Limit          int
+	Offset         int
 }
 
 // EventGrumblesResponse represents the response
@@ -62,12 +63,27 @@ func (ctrl *EventGrumblesController) GetEventGrumbles(
 		toxicLevelMax = &tl
 	}
 
+	// PurifiedStatusからIsPurifiedフィルタを設定
+	var isPurified *bool
+	if query.PurifiedStatus != nil {
+		switch *query.PurifiedStatus {
+		case "is_purified":
+			trueVal := true
+			isPurified = &trueVal
+		case "is_not_purified":
+			falseVal := false
+			isPurified = &falseVal
+		case "all":
+			// nilのまま（全て取得）
+		}
+	}
+
 	req := usecase.EventGrumblesRequest{
-		ToxicLevelMin:   toxicLevelMin,
-		ToxicLevelMax:   toxicLevelMax,
-		ExcludePurified: false, // イベントでは全て表示
-		Limit:           query.Limit,
-		Offset:          query.Offset,
+		ToxicLevelMin: toxicLevelMin,
+		ToxicLevelMax: toxicLevelMax,
+		IsPurified:    isPurified,
+		Limit:         query.Limit,
+		Offset:        query.Offset,
 	}
 
 	result, err := ctrl.eventGrumblesGetUC.Get(ctx, req)

--- a/internal/usecase/event_grumbles_get.go
+++ b/internal/usecase/event_grumbles_get.go
@@ -25,11 +25,11 @@ func NewEventGrumblesGetUseCase(grumbleRepo grumble.Repository, eventTimeSvc *sh
 
 // EventGrumblesRequest represents request parameters
 type EventGrumblesRequest struct {
-	ToxicLevelMin   *shared.ToxicLevel
-	ToxicLevelMax   *shared.ToxicLevel
-	ExcludePurified bool
-	Limit           int
-	Offset          int
+	ToxicLevelMin *shared.ToxicLevel
+	ToxicLevelMax *shared.ToxicLevel
+	IsPurified    *bool // nilの場合は全て、trueの場合は成仏済み、falseの場合は成仏していない
+	Limit         int
+	Offset        int
 }
 
 // EventGrumblesResponse represents the response
@@ -59,15 +59,10 @@ func (uc *EventGrumblesGetUseCase) Get(ctx context.Context, req EventGrumblesReq
 	targetDate := uc.eventTimeSvc.GetEventTargetDate(now)
 
 	// フィルタ構築
-	var isPurified *bool
-	if req.ExcludePurified {
-		falseVal := false
-		isPurified = &falseVal
-	}
 	filter := grumble.TimelineFilter{
 		ToxicLevelMin:  req.ToxicLevelMin,
 		ToxicLevelMax:  req.ToxicLevelMax,
-		IsPurified:     isPurified,
+		IsPurified:     req.IsPurified,
 		ExcludeExpired: false, // アーカイブなので期限チェック不要
 		Limit:          req.Limit,
 		Offset:         req.Offset,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -513,6 +513,16 @@ paths:
             minimum: 0
             default: 0
           description: オフセット
+        - name: purified_status
+          in: query
+          schema:
+            type: string
+            enum:
+              - is_purified
+              - is_not_purified
+              - all
+            default: all
+          description: 成仏ステータスフィルター (is_purified=成仏済み, is_not_purified=成仏していない, all=全て)
       responses:
         '200':
           description: イベント投稿リスト


### PR DESCRIPTION
## 概要
イベントアーカイブ取得API (GET /events/grumbles) に成仏ステータスフィルター機能を追加しました。

## 変更内容

### 1. クエリパラメータの追加
- `purified_status` パラメータを追加
  - `is_purified`: 成仏済みの愚痴のみ
  - `is_not_purified`: 成仏していない愚痴のみ
  - `all`: 全て表示（デフォルト）

### 2. UseCase層の改善
- `ExcludePurified` (bool) を削除
- `IsPurified` (*bool) に変更して3値対応を実現

### 3. 実装箇所
- `openapi.yaml`: APIスキーマ定義
- `internal/usecase/event_grumbles_get.go`: UseCaseロジック
- `internal/controller/event_grumbles_controller.go`: パラメータ変換処理
- `internal/api/api.gen.go`: 自動生成コード

## 効果
イベントアーカイブで成仏ステータスによる絞り込みが可能になり、ユーザーが見たい愚痴を柔軟にフィルタリングできるようになりました。