### PR TITLE
fix: return empty array for GetEvents endpoint instead of error

### DIFF
--- a/internal/api/strict_handler.go
+++ b/internal/api/strict_handler.go
@@ -48,9 +48,13 @@ func NewStrictControllerServer(
 	}
 }
 
-// GetEvents is currently not implemented.
+// GetEvents returns the list of events (currently returns empty array as events feature is not yet implemented).
 func (s *StrictControllerServer) GetEvents(ctx context.Context, _ GetEventsRequestObject) (GetEventsResponseObject, error) {
-	return nil, errors.New("GetEvents not implemented")
+	// Return empty events array for now (events feature not yet implemented)
+	events := []Event{}
+	return GetEvents200JSONResponse{
+		Events: &events,
+	}, nil
 }
 
 // GetEvent is currently not implemented.


### PR DESCRIPTION
Changed GetEvents endpoint to return an empty events array instead of throwing "not implemented" error. This prevents 500 errors on the statistics page while the events feature is under development.

🤖 Generated with [Claude Code](https://claude.com/claude-code)